### PR TITLE
feat: add mcp() hook to install @playwright/mcp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@
 
 ## Summary
 
-TODO: Add a short summary of this module.
+p6df module for Playwright: browser automation testing with VSCode integration
+and MCP server (`@playwright/mcp`) for AI-driven browser control.
 
 ## Contributing
 
@@ -37,6 +38,7 @@ TODO: Add a short summary of this module.
 
 - `p6df::modules::playwright::deps()`
 - `p6df::modules::playwright::langs()`
+- `p6df::modules::playwright::mcp()`
 - `p6df::modules::playwright::vscodes()`
 - `p6df::modules::playwright::vscodes::config()`
 

--- a/init.zsh
+++ b/init.zsh
@@ -57,3 +57,17 @@ p6df::modules::playwright::langs() {
 
   p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: p6df::modules::playwright::mcp()
+#
+#>
+######################################################################
+p6df::modules::playwright::mcp() {
+
+  p6_js_npm_global_install "@playwright/mcp"
+
+  p6_return_void
+}


### PR DESCRIPTION
## Summary

- `mcp()`: installs `@playwright/mcp` MCP server for AI-driven browser control
- Additive: `@playwright/test` remains in `langs()`; `@playwright/mcp` is MCP-only
- No `mcp::env()` needed (Playwright MCP requires no auth token)

## Test plan

- [ ] `p6df mcp p6df-playwright` installs `@playwright/mcp` globally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)