### PR TITLE
fix: install playwright-mcp via brew instead of npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@
 
 ## Summary
 
-p6df module for Playwright: browser automation testing with VSCode integration
-and MCP server (`@playwright/mcp`) for AI-driven browser control.
+p6df module for Playwright: browser testing framework, `@playwright/test` npm
+install, and MCP server (`playwright-mcp` via brew) for AI-driven browser
+automation and testing.
 
 ## Contributing
 

--- a/init.zsh
+++ b/init.zsh
@@ -67,7 +67,7 @@ p6df::modules::playwright::langs() {
 ######################################################################
 p6df::modules::playwright::mcp() {
 
-  p6_js_npm_global_install "@playwright/mcp"
+  p6df::core::homebrew::cli::brew::install playwright-mcp
 
   p6_return_void
 }


### PR DESCRIPTION
## Summary

- Replace `p6_js_npm_global_install "@playwright/mcp"` with `p6df::core::homebrew::cli::brew::install playwright-mcp` — a bottled Homebrew formula is available and preferred over npm global install

## Test plan

- [ ] `p6df mcp` installs `playwright-mcp` via brew

🤖 Generated with [Claude Code](https://claude.com/claude-code)