### PR TITLE
feat: add home::symlinks() for claude skills

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -16,6 +16,21 @@ p6df::modules::playwright::deps() {
 ######################################################################
 #<
 #
+# Function: p6df::modules::playwright::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_DIR
+#>
+######################################################################
+p6df::modules::playwright::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_DIR/lackeyjb/playwright-skill/skills/playwright-skill"                                        "$HOME/.claude/skills/playwright"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
 # Function: p6df::modules::playwright::vscodes()
 #
 #>


### PR DESCRIPTION
## Summary

- Adds `home::symlinks()` function to symlink Claude Code skills into `~/.claude/skills/`

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)