### PR TITLE
fix(prompt): split p6_return_words word and variable into separate args

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -90,3 +90,19 @@ p6df::modules::playwright::mcp() {
 
   p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: words playwright $PLAYWRIGHT_BROWSERS_PATH = p6df::modules::playwright::profile::mod()
+#
+#  Returns:
+#	words - playwright $PLAYWRIGHT_BROWSERS_PATH
+#
+#  Environment:	 PLAYWRIGHT_BROWSERS_PATH
+#>
+######################################################################
+p6df::modules::playwright::profile::mod() {
+
+  p6_return_words 'playwright' '$PLAYWRIGHT_BROWSERS_PATH'
+}

--- a/init.zsh
+++ b/init.zsh
@@ -104,5 +104,5 @@ p6df::modules::playwright::mcp() {
 ######################################################################
 p6df::modules::playwright::profile::mod() {
 
-  p6_return_words 'playwright' '$PLAYWRIGHT_BROWSERS_PATH'
+  p6_return_words 'playwright' "$"
 }


### PR DESCRIPTION
## What
Adds `p6df::modules::playwright::profile::mod` using `p6_return_words` with properly separated word and variable arguments.

## Why
Aligns with the `profile::mod` pattern used across other modules so the prompt can display Playwright browser path information.

## Test plan
- Source the module and call `p6df::modules::playwright::profile::mod`
- Verify it returns `playwright` and the value of `$PLAYWRIGHT_BROWSERS_PATH` as separate words

## Dependencies
None