### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::playwright::deps()
+#
+#>
+######################################################################
 p6df::modules::playwright::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-js
@@ -7,6 +13,13 @@ p6df::modules::playwright::deps() {
   )
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::playwright::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_DIR
+#>
 ######################################################################
 p6df::modules::playwright::home::symlinks() {
 
@@ -16,6 +29,12 @@ p6df::modules::playwright::home::symlinks() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::playwright::langs()
+#
+#>
+######################################################################
 p6df::modules::playwright::langs() {
 
   p6_js_npm_global_install "@playwright/test"
@@ -23,6 +42,12 @@ p6df::modules::playwright::langs() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::playwright::mcp()
+#
+#>
 ######################################################################
 p6df::modules::playwright::mcp() {
 
@@ -34,6 +59,12 @@ p6df::modules::playwright::mcp() {
   p6_return_void
 }
 ######################################################################
+#<
+#
+# Function: p6df::modules::playwright::vscodes()
+#
+#>
+######################################################################
 p6df::modules::playwright::vscodes() {
 
   p6df::modules::vscode::extension::install ms-playwright.playwright
@@ -41,6 +72,12 @@ p6df::modules::playwright::vscodes() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::playwright::vscodes::config()
+#
+#>
 ######################################################################
 p6df::modules::playwright::vscodes::config() {
 
@@ -53,40 +90,3 @@ EOF
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::playwright::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::playwright::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_DIR
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::playwright::vscodes()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::playwright::vscodes::config()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::playwright::langs()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::playwright::mcp()
-#
-#>

--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::playwright::deps()
-#
-#>
-######################################################################
 p6df::modules::playwright::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-js
@@ -13,13 +7,6 @@ p6df::modules::playwright::deps() {
   )
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::playwright::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_DIR
-#>
 ######################################################################
 p6df::modules::playwright::home::symlinks() {
 
@@ -29,11 +16,23 @@ p6df::modules::playwright::home::symlinks() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::playwright::vscodes()
-#
-#>
+p6df::modules::playwright::langs() {
+
+  p6_js_npm_global_install "@playwright/test"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::playwright::mcp() {
+
+  p6_js_npm_global_install "@playwright/mcp"
+
+  p6df::modules::anthropic::mcp::server::add "playwright" "npx" "-y" "@playwright/mcp"
+  p6df::modules::openai::mcp::server::add "playwright" "npx" "-y" "@playwright/mcp"
+
+  p6_return_void
+}
 ######################################################################
 p6df::modules::playwright::vscodes() {
 
@@ -42,12 +41,6 @@ p6df::modules::playwright::vscodes() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::playwright::vscodes::config()
-#
-#>
 ######################################################################
 p6df::modules::playwright::vscodes::config() {
 
@@ -63,30 +56,37 @@ EOF
 ######################################################################
 #<
 #
-# Function: p6df::modules::playwright::langs()
+# Function: p6df::modules::playwright::deps()
 #
 #>
 ######################################################################
-p6df::modules::playwright::langs() {
-
-  p6_js_npm_global_install "@playwright/test"
-
-  p6_return_void
-}
-
+#<
+#
+# Function: p6df::modules::playwright::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_DIR
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::playwright::vscodes()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::playwright::vscodes::config()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::playwright::langs()
+#
+#>
 ######################################################################
 #<
 #
 # Function: p6df::modules::playwright::mcp()
 #
 #>
-######################################################################
-p6df::modules::playwright::mcp() {
-
-  p6_js_npm_global_install "@playwright/mcp"
-
-  p6df::modules::anthropic::mcp::server::add "playwright" "npx" "-y" "@playwright/mcp"
-  p6df::modules::openai::mcp::server::add "playwright" "npx" "-y" "@playwright/mcp"
-
-  p6_return_void
-}


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None